### PR TITLE
Revert js_pipeline_operator to pipe_operator id for old keys

### DIFF
--- a/state_of_js.yml
+++ b/state_of_js.yml
@@ -298,9 +298,9 @@ translations:
     t: Зіставлення із шаблоном
   - key: options.currently_missing_from_js.pattern_matching.description
     t: "`match` для пошуку об'єктів через зіставлення із шаблоном"
-  - key: options.currently_missing_from_js.pipe_operator
+  - key: options.currently_missing_from_js.js_pipeline_operator
     t: Конвеєрний оператор (Pipe)
-  - key: options.currently_missing_from_js.pipe_operator.description
+  - key: options.currently_missing_from_js.js_pipeline_operator.description
     t: Новий оператор `|>` для передавання результату однієї функції в іншу.
   - key: options.currently_missing_from_js.decorators
     t: Декоратори
@@ -335,10 +335,10 @@ translations:
     aliasFor: options.currently_missing_from_js.pattern_matching
   - key: options.top_currently_missing_from_js.pattern_matching.description
     aliasFor: options.currently_missing_from_js.pattern_matching.description
-  - key: options.top_currently_missing_from_js.pipe_operator
-    aliasFor: options.currently_missing_from_js.pipe_operator
-  - key: options.top_currently_missing_from_js.pipe_operator.description
-    aliasFor: options.currently_missing_from_js.pipe_operator.description
+  - key: options.top_currently_missing_from_js.js_pipeline_operator
+    aliasFor: options.currently_missing_from_js.js_pipeline_operator
+  - key: options.top_currently_missing_from_js.js_pipeline_operator.description
+    aliasFor: options.currently_missing_from_js.js_pipeline_operator.description
   - key: options.top_currently_missing_from_js.decorators
     aliasFor: options.currently_missing_from_js.decorators
   - key: options.top_currently_missing_from_js.decorators.description
@@ -372,7 +372,7 @@ translations:
     t: Декоратори
   - key: options.top_currently_missing_from_js.multithreading
     t: Багатопотоковість
-  - key: options.top_currently_missing_from_js.pipe_operator
+  - key: options.top_currently_missing_from_js.js_pipeline_operator
     t: Конвеєрний оператор (Pipe)
   - key: options.top_currently_missing_from_js.native_observables
     t: Нативний тип "Observable"
@@ -581,7 +581,7 @@ translations:
   # - key: features.pattern_matching
   #   t: Pattern Matching
 
-  # - key: features.pipe_operator
+  # - key: features.js_pipeline_operator
   #   t: Pipe Operator
 
   # - key: features.immutable_data_structures


### PR DESCRIPTION
This reverts commit 3eb9bdb618c939dcd020f22798dfe921da1b84a4.

(I haven't noticed this [commit](https://github.com/Devographics/locale-en-US/commit/aa4709e513bb54edd924c81a0b34c614560cf9aa) before change)